### PR TITLE
This screws up the navigation drawer:

### DIFF
--- a/src/com/aokp/romcontrol/ROMControlActivity.java
+++ b/src/com/aokp/romcontrol/ROMControlActivity.java
@@ -154,9 +154,6 @@ public class ROMControlActivity extends PreferenceDrawerActivity implements Butt
                 p.edit().putBoolean(KEY_USE_ENGLISH_LOCALE, !useEnglishLocale).apply();
                 recreate();
                 return true;
-            case android.R.id.home:
-                onBackPressed();
-                return true;
             default:
                 return super.onContextItemSelected(item);
         }


### PR DESCRIPTION
Because the MenuDrawers icon becomes the back button. Meaning, when we go to try and open the drawer, it will end up exiting out of the application and back into Settings